### PR TITLE
handle file permission issue when it tries to update the deprected tu…

### DIFF
--- a/lib/tunnel_binary.js
+++ b/lib/tunnel_binary.js
@@ -19,7 +19,7 @@ function TunnelBinary(httpTunnelConfig, options) {
   this.binaryVersion = 'v3';
   if (options['legacy']) {
     this.binaryVersion = 'v2';
-    executableName = "ltcomponent";
+    executableName = 'ltcomponent';
   }
   this.httpTunnelConfig = httpTunnelConfig;
   this.hostOS = process.platform;
@@ -37,13 +37,14 @@ function TunnelBinary(httpTunnelConfig, options) {
   this.httpPath = this.httpTunnelConfig.jsonResponse.binaryLinks[this.platform][this.binaryVersion][
     this.bits
   ].httpPath;
-  this.binaryName = this.httpTunnelConfig.jsonResponse.binaryLinks[this.platform][this.binaryVersion][
-    this.bits
-  ].binaryName;
-  this.httpHashContents = this.httpTunnelConfig.jsonResponse.binaryLinks[this.platform][this.binaryVersion][
-    this.bits
-  ].hash;
-  this.localHashContents = localTunnelConfig_.binaryLinks[this.platform][this.binaryVersion][this.bits].hash;
+  this.binaryName = this.httpTunnelConfig.jsonResponse.binaryLinks[this.platform][
+    this.binaryVersion
+  ][this.bits].binaryName;
+  this.httpHashContents = this.httpTunnelConfig.jsonResponse.binaryLinks[this.platform][
+    this.binaryVersion
+  ][this.bits].hash;
+  this.localHashContents =
+    localTunnelConfig_.binaryLinks[this.platform][this.binaryVersion][this.bits].hash;
   logger = this.httpTunnelConfig.logger;
 
   /**
@@ -91,7 +92,7 @@ function TunnelBinary(httpTunnelConfig, options) {
       if (this.checkPath_(destParentDir)) {
         this.rmDir(destParentDir);
       }
-      fs.mkdirSync(destParentDir, { recursive : true });
+      fs.mkdirSync(destParentDir, { recursive: true });
       // Generate binary path.
       var binaryPath = path.join(destParentDir, this.binaryName);
       var fileStream = fs.createWriteStream(binaryPath);
@@ -217,10 +218,18 @@ function TunnelBinary(httpTunnelConfig, options) {
           return fnCallback(binaryPath);
         } else {
           console.log(`Binary is deprecated`);
-          fs.writeFileSync(
-            __dirname + '/cfg/node-tunnel-config-v3-latest.json',
-            JSON.stringify(this.httpTunnelConfig.jsonResponse)
-          );
+          try {
+            fs.writeFileSync(
+              __dirname + '/cfg/node-tunnel-config-v3-latest.json',
+              JSON.stringify(this.httpTunnelConfig.jsonResponse)
+            );
+          } catch (e) {
+            console.log(
+              'Permission denied! Please execute the command using sudo or provide the required read & write permissions to file : ',
+              __dirname + '/cfg/node-tunnel-config-v3-latest.json'
+            );
+            throw e;
+          }
           localTunnelConfig_ = this.httpTunnelConfig.jsonResponse;
           that.download_(conf, destParentDir, 5, fnCallback);
         }
@@ -263,7 +272,8 @@ function TunnelBinary(httpTunnelConfig, options) {
    */
   this.availableDirs_ = function() {
     var orderedPathLength = this.orderedPaths.length;
-    var _path, iCounter = 0;
+    var _path,
+      iCounter = 0;
     for (var i = 0; i < orderedPathLength; i++) {
       iCounter++;
       _path = this.orderedPaths[i];
@@ -284,7 +294,7 @@ function TunnelBinary(httpTunnelConfig, options) {
   this.makePath_ = function(path) {
     try {
       if (!this.checkPath_(path)) {
-        fs.mkdirSync(path, { recursive : true });
+        fs.mkdirSync(path, { recursive: true });
       }
       return true;
     } catch (e) {
@@ -333,7 +343,11 @@ function TunnelBinary(httpTunnelConfig, options) {
       fs.rmdirSync(dir);
     }
   };
-  this.orderedPaths = [path.join(this.homeDir_(), '.lambdatest', this.binaryVersion), path.join(process.cwd(), this.binaryVersion), path.join(os.tmpdir(), this.binaryVersion )];
+  this.orderedPaths = [
+    path.join(this.homeDir_(), '.lambdatest', this.binaryVersion),
+    path.join(process.cwd(), this.binaryVersion),
+    path.join(os.tmpdir(), this.binaryVersion)
+  ];
 }
 
 module.exports = TunnelBinary;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lambdatest/node-tunnel",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Nodejs bindings for LambdaTest Tunnel",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
https://lambdatest.atlassian.net/browse/MLE-3611

changes : handle file permission issue when it tries to update the deprecated tunnel binary for cypress tests