### PR TITLE
fix to support node tunnel on mac m1

### DIFF
--- a/lib/tunnel_binary.js
+++ b/lib/tunnel_binary.js
@@ -23,7 +23,7 @@ function TunnelBinary(httpTunnelConfig, options) {
   }
   this.httpTunnelConfig = httpTunnelConfig;
   this.hostOS = process.platform;
-  this.bits = process.arch === 'x64' ? '64bit' : '32bit';
+  this.bits = process.arch === 'x64' || process.arch === 'arm64' ? '64bit' : '32bit';
   if (this.hostOS.match(/darwin|mac os/i)) {
     this.platform = 'mac';
   } else if (this.hostOS.match(/mswin|msys|mingw|cygwin|bccwin|wince|emc|win32/i)) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lambdatest/node-tunnel",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "description": "Nodejs bindings for LambdaTest Tunnel",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
Fix to start node tunnel on mac m1 chip machines
https://lambdatest.atlassian.net/browse/IN-1533