### PR TITLE
docs: fix logo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![LambdaTest Logo](https://www.lambdatest.com/static/images/logo.svg)
+![LambdaTest Logo](https://www.lambdatest.com/resources/images/logos/logo.svg)
 
 # LambdaTest Nodejs bindings for Tunnel 
 


### PR DESCRIPTION
The LambdaTest logo link was broken in [`README.md`](https://github.com/LambdaTest/node-tunnel/blob/d97e19324148589e88527968839c2344e0f71f32/README.md). This PR fixes that (cf. [`README.md`](https://github.com/vil02/node-tunnel/blob/22870343015241cffd53bf125df9fdb2092f15c8/README.md)).