### PR TITLE
feat: select tunnel config endpoint by env

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -1,10 +1,14 @@
-var httpTunnelConfigPath = 'https://downloads.lambdatest.com/tunnel/node-tunnel-config-v3-latest.json',
+var prodTunnelConfigPath = 'https://downloads.lambdatest.com/tunnel/node-tunnel-config-v3-latest.json',
+  stageTunnelConfigPath = 'https://stage-downloads.lambdatestinternal.com/tunnel/node-tunnel-config-v3-latest.json',
   httpTunnelLogUrl = 'https://oinwgsy681.execute-api.us-east-1.amazonaws.com/prod/addLog',
   https = require('https'),
   urlParse = require('url'),
   HttpsProxyAgent = require('https-proxy-agent'),
   util = require('./util');
 module.exports = function(options, fnCallback) {
+  // stage env resolves config (and thus AuthUrl + binaryLinks) to stage
+  var env = String(options.env || options.environment || options.e || 'prod').toLowerCase();
+  var httpTunnelConfigPath = env === 'stage' ? stageTunnelConfigPath : prodTunnelConfigPath;
   var reqOptions = urlParse.parse(httpTunnelConfigPath);
   var proxyOpts = util.getProxyOpts_(options);
   if (Object.keys(proxyOpts).length) {


### PR DESCRIPTION
## What

Adds environment support to the tunnel client. `start()` now selects the config endpoint based on the `env` option, so credential verification (`AuthUrl`) and binary resolution (`binaryLinks`) resolve to the matching environment instead of always using prod.

## How

`lib/config.js` picks the config URL from `options.env` / `options.environment` / `options.e`. Prod remains the default, so behaviour is unchanged for all existing callers.

## Compatibility

Opt-in and backward compatible — callers that don't pass `env` (or pass `env: 'prod'`) keep the current behaviour.
