### PR TITLE
docs: add Browser Cloud Tunnel docs link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 [![Node Tunnel health check](https://github.com/LambdaTest/node-tunnel/actions/workflows/healthcheck.yml/badge.svg?branch=master)](https://github.com/LambdaTest/node-tunnel/actions/workflows/healthcheck.yml)
 
+📖 **Documentation:** [Browser Cloud Tunnel Guide](https://www.testmuai.com/support/docs/browser-cloud-tunnel/)
+
 ## Installation
 
 ```


### PR DESCRIPTION
## Summary
- Added specific support documentation link to README
- Replaces generic doc link with the correct product-specific documentation URL

## Context
Per TE-28506: Update npm README pages with relevant support docs links.

## Test plan
- [ ] Verify doc link renders correctly on npm after publish